### PR TITLE
Force param to app aupdate and normalization of app id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 	</developers>
 
 	<properties>
-		<feign-version>6.1.3</feign-version>
+		<feign-version>8.1.0</feign-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
 	</properties>

--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -2,8 +2,7 @@ package mesosphere.marathon.client;
 
 import java.util.List;
 
-import javax.inject.Named;
-
+import feign.Param;
 import mesosphere.marathon.client.model.v2.App;
 import mesosphere.marathon.client.model.v2.DeleteAppTaskResponse;
 import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse;
@@ -15,6 +14,7 @@ import mesosphere.marathon.client.model.v2.GetServerInfoResponse;
 import mesosphere.marathon.client.model.v2.GetTasksResponse;
 import mesosphere.marathon.client.model.v2.Group;
 import mesosphere.marathon.client.model.v2.Result;
+import mesosphere.marathon.client.utils.AppIdNormalizer;
 import mesosphere.marathon.client.utils.MarathonException;
 import feign.RequestLine;
 
@@ -24,10 +24,10 @@ public interface Marathon {
 	GetAppsResponse getApps();
 
 	@RequestLine("GET /v2/apps/{id}")
-	GetAppResponse getApp(@Named("id") String id) throws MarathonException;
+	GetAppResponse getApp(@Param(value = "id", expander = AppIdNormalizer.class) String id) throws MarathonException;
 
 	@RequestLine("GET /v2/apps/{id}/tasks")
-	GetAppTasksResponse getAppTasks(@Named("id") String id);
+	GetAppTasksResponse getAppTasks(@Param(value = "id", expander = AppIdNormalizer.class) String id);
 
 	@RequestLine("GET /v2/tasks")
 	GetTasksResponse getTasks();
@@ -35,32 +35,34 @@ public interface Marathon {
 	@RequestLine("POST /v2/apps")
 	App createApp(App app) throws MarathonException;
 
-	@RequestLine("PUT /v2/apps/{app_id}")
-	void updateApp(@Named("app_id") String appId, App app);
+	@RequestLine("PUT /v2/apps/{app_id}?force={force}")
+	void updateApp(@Param(value = "app_id", expander = AppIdNormalizer.class) String appId, App app,
+                   @Param("force") boolean force) throws MarathonException;
 
 	@RequestLine("POST /v2/apps/{id}/restart?force={force}")
-	void restartApp(@Named("id") String id,@Named("force") boolean force);
+	void restartApp(@Param(value = "id", expander = AppIdNormalizer.class) String id,
+                    @Param("force") boolean force);
 
 	@RequestLine("DELETE /v2/apps/{id}")
-	Result deleteApp(@Named("id") String id) throws MarathonException;
+	Result deleteApp(@Param(value = "id", expander = AppIdNormalizer.class) String id) throws MarathonException;
 
 	@RequestLine("DELETE /v2/apps/{app_id}/tasks?host={host}&scale={scale}")
-	DeleteAppTasksResponse deleteAppTasks(@Named("app_id") String appId,
-			@Named("host") String host, @Named("scale") String scale);
+	DeleteAppTasksResponse deleteAppTasks(@Param(value = "app_id", expander = AppIdNormalizer.class) String appId,
+			@Param("host") String host, @Param("scale") String scale);
 
 	@RequestLine("DELETE /v2/apps/{app_id}/tasks/{task_id}?scale={scale}")
-	DeleteAppTaskResponse deleteAppTask(@Named("app_id") String appId,
-			@Named("task_id") String taskId, @Named("scale") String scale);
+	DeleteAppTaskResponse deleteAppTask(@Param(value = "app_id", expander = AppIdNormalizer.class) String appId,
+			@Param("task_id") String taskId, @Param("scale") String scale);
 
     // Groups
 	@RequestLine("POST /v2/groups")
 	Result createGroup(Group group) throws MarathonException;
 	
 	@RequestLine("DELETE /v2/groups/{id}")
-	Result deleteGroup(@Named("id") String id) throws MarathonException;
+	Result deleteGroup(@Param("id") String id) throws MarathonException;
 	
 	@RequestLine("GET /v2/groups/{id}")
-	Group getGroup(@Named("id") String id) throws MarathonException;
+	Group getGroup(@Param("id") String id) throws MarathonException;
 
     // Tasks
 
@@ -69,10 +71,10 @@ public interface Marathon {
 	List<Deployment> getDeployments();
 	
 	@RequestLine("DELETE /v2/deployments/{deploymentId}")
-	void cancelDeploymentAndRollback(@Named("deploymentId") String id);
+	void cancelDeploymentAndRollback(@Param("deploymentId") String id);
 	
 	@RequestLine("DELETE /v2/deployments/{deploymentId}?force=true")
-	void cancelDeployment(@Named("deploymentId") String id);
+	void cancelDeployment(@Param("deploymentId") String id);
 
     // Event Subscriptions
 

--- a/src/main/java/mesosphere/marathon/client/utils/AppIdNormalizer.java
+++ b/src/main/java/mesosphere/marathon/client/utils/AppIdNormalizer.java
@@ -1,0 +1,17 @@
+package mesosphere.marathon.client.utils;
+
+import feign.Param;
+
+import java.util.Objects;
+
+/**
+ * Removes "/" prefix that is commonly used in Marathon app id.
+ */
+public class AppIdNormalizer implements Param.Expander {
+    @Override
+    public String expand(Object o) {
+        String id = Objects.requireNonNull(o).toString().trim();
+        if (id.startsWith("/")) return id.substring(1);
+        return id;
+    }
+}


### PR DESCRIPTION
Hello Will!

While looking on the net I found your fork of the Marathon client. It looks like something I realy need. Please review this pull request. I added missing "force" param to the update method. I also upgraded the Feign library so it is possible to normalize app's id on the fly using new "Param" annotation.
There is a small test for it.

If you find this pull request ok then please merge it and please release a new version of the library. If you have any questions do not hesitate to ask.

Kind regards,
Marcin Jakubowski
