### PR TITLE
Expose the HTTP status code in MarathonException.

### DIFF
--- a/src/main/java/mesosphere/marathon/client/utils/MarathonException.java
+++ b/src/main/java/mesosphere/marathon/client/utils/MarathonException.java
@@ -2,21 +2,16 @@ package mesosphere.marathon.client.utils;
 
 public class MarathonException extends Exception {
 	private static final long serialVersionUID = 1L;
-	private int status;
-	private String message;
-	
-	public MarathonException(int status, String message) {
-		this.status = status;
-		this.message = message;
-	}
-	
-	@Override
-	public String getMessage() {
-		return message + " (http status: " + status + ")";
+
+	public final int statusCode;
+
+	public MarathonException(int statusCode, String message) {
+		super(String.format("%s (HTTP status: %d)", message, statusCode));
+		this.statusCode = statusCode;
 	}
 
 	@Override
 	public String toString() {
-		return message + " (http status: " + status + ")";
+		return getMessage();
 	}
 }


### PR DESCRIPTION
Allow callers to inspect the HTTP status code that motivated the exception being thrown in order to better ascertain the cause of the failure.

Fixes willroden/marathon-client#5.
