### PR TITLE
Accept a Feign$Builder for customizing clients.

### DIFF
--- a/src/main/java/mesosphere/marathon/client/MarathonClient.java
+++ b/src/main/java/mesosphere/marathon/client/MarathonClient.java
@@ -27,9 +27,14 @@ public class MarathonClient {
 	}
 	
 	public static Marathon getInstance(String endpoint) {
-		GsonDecoder decoder = new GsonDecoder(ModelUtils.GSON);
-		GsonEncoder encoder = new GsonEncoder(ModelUtils.GSON);
-		return Feign.builder().encoder(encoder).decoder(decoder)
+		return getInstance(Feign.builder(), endpoint);
+	}
+
+	public static Marathon getInstance(Feign.Builder builder, String endpoint) {
+		final GsonDecoder decoder = new GsonDecoder(ModelUtils.GSON);
+		final GsonEncoder encoder = new GsonEncoder(ModelUtils.GSON);
+		return builder
+				.encoder(encoder).decoder(decoder)
 				.errorDecoder(new MarathonErrorDecoder())
 				.requestInterceptor(new MarathonHeadersInterceptor())
 				.target(Marathon.class, endpoint);


### PR DESCRIPTION
In order to [use Feign with Ribbon](https://github.com/Netflix/feign/tree/master/ribbon), callers need to first call `Feign$Builder#client()` before Feign finishes preparing the client handle. While it would be possible to overload `MarathonClient#getInstance()` to accept a `Client` reference, there are other options on `Feign$Builder` that we can accommodate by accepting an existing `Builder` instance.

Note that `MarathonClient#getInstance()` will overwrite any preceding changes to the encoder, decoder, and error decoder. If you feel that this overwriting is too confusing, I could instead propose just exposing the following signature:

```
    public static Marathon getInstance(Client client, String endpoint)
```

However, in doing so, we'd have to call on `Feign$Builder#client()` conditionally if we were to share the remaining client preparation procedure as I did here.
