### PR TITLE
Allow updating of an existing application group.

### DIFF
--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -57,10 +57,14 @@ public interface Marathon {
     // Groups
 	@RequestLine("POST /v2/groups")
 	Result createGroup(Group group) throws MarathonException;
-	
+
+	@RequestLine("PUT /v2/groups/{id}")
+	Result updateGroup(@Param("id") String id, Group group, @Param("force") boolean force,
+			@Param("dryRun") boolean dryRun) throws MarathonException;
+
 	@RequestLine("DELETE /v2/groups/{id}")
 	Result deleteGroup(@Param("id") String id) throws MarathonException;
-	
+
 	@RequestLine("GET /v2/groups/{id}")
 	Group getGroup(@Param("id") String id) throws MarathonException;
 


### PR DESCRIPTION
Marathon allows application groups to be updated, possibly inducing a new deployment to start. The PUT resource is documented here:

  https://mesosphere.github.io/marathon/docs/rest-api.html#put-v2-groups-groupid

Note that even though the documentation doesn't mention it, this resource accepts a "_dry run_" flag, per the definition here:

  https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala#L118

Hence the third parameter on the new `Marathon#updateGroup()` method.
