### PR TITLE
Allow filtering in application set query.

### DIFF
--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -23,6 +23,11 @@ public interface Marathon {
 	@RequestLine("GET /v2/apps")
 	GetAppsResponse getApps();
 
+	@RequestLine("GET /v2/apps?cmd={cmd}&id={id}&label={labelSelector}")
+	GetAppsResponse filterApps(@Param("cmd") String command,
+			@Param(value = "id", expander = AppIdNormalizer.class) String id,
+			@Param("labelSelector") String labelSelector);
+
 	@RequestLine("GET /v2/apps/{id}")
 	GetAppResponse getApp(@Param(value = "id", expander = AppIdNormalizer.class) String id) throws MarathonException;
 


### PR DESCRIPTION
Expose the command, ID, and label selector filter options [accepted by Marathon's "/v2/apps" GET method](https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala#L48). All three are optional, in that Feign will drop any query parameters with a corresponding null argument value. Calling `Marathon#filterApps(null, null, null)` behaves indistinguishably from calling `Marathon#getApps()`.

The filtering implementation is defined by [`mesosphere.marathon.api.v2AppsResource.search()`](https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala#L268). For the first two parameters (command and ID), Marathon will select only those applications that match the given command or ID when compared ignoring case.

The third label selector parameter obeys the format [documented in file _LabelSelector.scala_](https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/api/v2/LabelSelector.scala#L19).

Note that I did not overload `Marathon#getApps()`, but instead called this new method `filterApps()`. If you'd prefer to keep the name with an overload, I'm willing to change that.
