### PR TITLE
Expose existing applications' "version" field.

### DIFF
--- a/src/main/java/mesosphere/marathon/client/model/v2/App.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/App.java
@@ -11,6 +11,7 @@ import mesosphere.marathon.client.utils.ModelUtils;
 public class App {
 	private String id;
 	private String cmd;
+	private String version;
 	private Integer instances;
 	private Double cpus;
 	private Double mem;
@@ -50,6 +51,14 @@ public class App {
 
 	public void setCmd(String cmd) {
 		this.cmd = cmd;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
 	}
 
 	public Integer getInstances() {


### PR DESCRIPTION
The "version" field is provided by Marathon when presenting existing applications, and is not intended to be provided as part of request to create an application. The format is that produced by the Joda-Time library's `ISODateTimeFormat` class's `toString()` method (_ISO 8601_).

For now I only exposed the received version value as a string. Again, I'd like to help callers translate this to a proper date, but I'm reluctant to introduce a dependency on Joda-Time, given that Java 8's date handling may be good enough.

Fixes willroden/marathon-client#14.
