### PR TITLE
Add missing ConstraintOperator enum elements

### DIFF
--- a/src/main/java/mesosphere/marathon/client/model/v2/ConstraintOperator.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/ConstraintOperator.java
@@ -1,5 +1,13 @@
 package mesosphere.marathon.client.model.v2;
 
 public enum ConstraintOperator {
-	UNIQUE, CLUSTER, GROUP_BY;
+	// Per the Constraint.Operator enum defined in file
+	//   marathon/src/main/proto/marathon.proto
+	// and the JSON schema defined in file
+	//   marathon/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json:
+	UNIQUE,
+	CLUSTER,
+	GROUP_BY,
+	LIKE,
+	UNLIKE;
 }


### PR DESCRIPTION
The Marathon constraint operator set has grown to [include the "LIKE" and "UNLIKE" operators](https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json#L65). I noticed those two were still missing in our `mesosphere.marathon.client.model.v2.ConstraintOperator` enum.
